### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/doxia/wrapper/AbstractFileWrapper.java
+++ b/src/main/java/org/apache/maven/doxia/wrapper/AbstractFileWrapper.java
@@ -26,9 +26,6 @@ import java.util.Objects;
 import com.ibm.icu.text.CharsetDetector;
 import org.apache.commons.lang3.StringUtils;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-
 /**
  * Abstract File wrapper for Doxia converter.
  *
@@ -49,7 +46,7 @@ abstract class AbstractFileWrapper {
      * @throws IllegalArgumentException if any
      */
     AbstractFileWrapper(String absolutePath, String encoding) throws UnsupportedEncodingException {
-        if (isEmpty(absolutePath)) {
+        if (absolutePath == null || absolutePath.isEmpty()) {
             throw new IllegalArgumentException("absolutePath is required");
         }
 
@@ -59,12 +56,12 @@ abstract class AbstractFileWrapper {
         }
         this.file = filetoset;
 
-        if (isNotEmpty(encoding) && !encoding.equalsIgnoreCase(encoding) && !Charset.isSupported(encoding)) {
+        if ((encoding != null && !encoding.isEmpty()) && !encoding.equalsIgnoreCase(encoding) && !Charset.isSupported(encoding)) {
             throw new UnsupportedEncodingException("The encoding '" + encoding
                     + "' is not a valid one. The supported charsets are: "
                     + StringUtils.join(CharsetDetector.getAllDetectableCharsets(), ", "));
         }
-        this.encoding = (isNotEmpty(encoding) ? encoding : AUTO_ENCODING);
+        this.encoding = (encoding != null && !encoding.isEmpty()) ? encoding : AUTO_ENCODING;
     }
 
     /**

--- a/src/main/java/org/apache/maven/doxia/wrapper/AbstractFileWrapper.java
+++ b/src/main/java/org/apache/maven/doxia/wrapper/AbstractFileWrapper.java
@@ -56,7 +56,9 @@ abstract class AbstractFileWrapper {
         }
         this.file = filetoset;
 
-        if ((encoding != null && !encoding.isEmpty()) && !encoding.equalsIgnoreCase(encoding) && !Charset.isSupported(encoding)) {
+        if ((encoding != null && !encoding.isEmpty())
+                && !encoding.equalsIgnoreCase(encoding)
+                && !Charset.isSupported(encoding)) {
             throw new UnsupportedEncodingException("The encoding '" + encoding
                     + "' is not a valid one. The supported charsets are: "
                     + StringUtils.join(CharsetDetector.getAllDetectableCharsets(), ", "));

--- a/src/main/java/org/apache/maven/doxia/wrapper/OutputStreamWrapper.java
+++ b/src/main/java/org/apache/maven/doxia/wrapper/OutputStreamWrapper.java
@@ -23,8 +23,6 @@ import java.util.Objects;
 
 import org.apache.maven.doxia.DefaultConverter;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 /**
  * Wrapper for an output stream.
  *
@@ -79,7 +77,7 @@ public class OutputStreamWrapper {
      */
     public static OutputStreamWrapper valueOf(OutputStream out, String format, String encoding) {
         Objects.requireNonNull(out, "output writer is required");
-        if (isEmpty(format)) {
+        if (format == null || format.isEmpty()) {
             throw new IllegalArgumentException("output format is required");
         }
 


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu