### PR TITLE
[DOXIATOOLS-90] Optionally first rename input to output, commit and then

### DIFF
--- a/src/main/java/org/apache/maven/doxia/Converter.java
+++ b/src/main/java/org/apache/maven/doxia/Converter.java
@@ -29,6 +29,12 @@ import org.apache.maven.doxia.wrapper.OutputStreamWrapper;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  */
 public interface Converter {
+    enum PostProcess {
+        NONE,
+        REMOVE_AFTER_CONVERSION,
+        GIT_MV_INPUT_TO_OUTPUT,
+    }
+
     /**
      * @param input an input file wrapper, not null.
      * @param output an output file wrapper, not null.
@@ -55,4 +61,6 @@ public interface Converter {
      * @param formatOutput <code>true</code> to format the generated files, <code>false</code> otherwise.
      */
     void setFormatOutput(boolean formatOutput);
+
+    void setPostProcess(PostProcess postProcess);
 }

--- a/src/main/java/org/apache/maven/doxia/cli/CLIManager.java
+++ b/src/main/java/org/apache/maven/doxia/cli/CLIManager.java
@@ -49,6 +49,8 @@ class CLIManager {
 
     static final String REMOVE_IN = "removeIn";
 
+    static final String GIT_MV_INPUT_TO_OUTPUT = "gitMvInputToOutput";
+
     /** out String */
     static final String OUT = "out";
 
@@ -98,6 +100,10 @@ class CLIManager {
         OPTIONS.addOption(Option.builder(REMOVE_IN)
                 .longOpt("removeInputAfterConversion")
                 .desc("Whether to remove the input file(s) after successful conversion")
+                .build());
+        OPTIONS.addOption(Option.builder(GIT_MV_INPUT_TO_OUTPUT)
+                .desc(
+                        "When this flag is set the input file(s) are first moved to the output file(s), then committed and afterwards replaced with conversion result to keep the Git history")
                 .build());
         OPTIONS.addOption(Option.builder(OUT)
                 .longOpt("output")

--- a/src/main/java/org/apache/maven/doxia/wrapper/InputFileWrapper.java
+++ b/src/main/java/org/apache/maven/doxia/wrapper/InputFileWrapper.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.doxia.wrapper;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 
@@ -37,11 +36,6 @@ public class InputFileWrapper extends AbstractFileWrapper {
     private final DefaultConverter.DoxiaFormat format;
 
     /**
-     * If true, the related input file(s) will be removed after the conversion.
-     */
-    private final boolean removeAfterConversion;
-
-    /**
      * Private constructor.
      *
      * @param absolutePath not null
@@ -50,13 +44,11 @@ public class InputFileWrapper extends AbstractFileWrapper {
      * @throws UnsupportedEncodingException if the encoding is unsupported.
      * @throws FileNotFoundException if the file for absolutePath is not found.
      */
-    private InputFileWrapper(
-            String absolutePath, DefaultConverter.DoxiaFormat format, String charsetName, boolean removeAfterConversion)
+    private InputFileWrapper(String absolutePath, DefaultConverter.DoxiaFormat format, String charsetName)
             throws UnsupportedEncodingException, FileNotFoundException {
         super(absolutePath, charsetName);
 
         this.format = format;
-        this.removeAfterConversion = removeAfterConversion;
         if (!getFile().exists()) {
             throw new FileNotFoundException("The file '" + getFile().getAbsolutePath() + "' doesn't exist.");
         }
@@ -72,42 +64,20 @@ public class InputFileWrapper extends AbstractFileWrapper {
      */
     public static InputFileWrapper valueOf(String absolutePath, DefaultConverter.DoxiaFormat format)
             throws UnsupportedEncodingException, FileNotFoundException {
-        return valueOf(absolutePath, format, WriterFactory.UTF_8, false);
+        return valueOf(absolutePath, format, WriterFactory.UTF_8);
     }
 
-    /**
-     * Performs potential clean up operations on the given file
-     * @param file the file to clean up, not null.
-     * @return {@code true} if the file was removed.
-     */
-    public boolean cleanUp(File file) {
-        if (!file.toString().startsWith(getFile().toString())) {
-            throw new IllegalStateException(
-                    "The given file " + file + " is not related to the input file: " + getFile());
-        }
-        if (removeAfterConversion) {
-            return file.delete();
-        }
-        return false;
-    }
-
-    public static InputFileWrapper valueOf(String absolutePath, DefaultConverter.DoxiaFormat format, String charsetName)
-            throws UnsupportedEncodingException, FileNotFoundException {
-        return valueOf(absolutePath, format, charsetName, false);
-    }
     /**
      * @param absolutePath for a wanted file or a wanted directory, not null.
      * @param format not null
      * @param charsetName could be null
-     * @param removeAfterConversion if true, the file will be removed after the conversion
      * @return a type safe input reader
      * @throws UnsupportedEncodingException if the encoding is unsupported.
      * @throws FileNotFoundException if the file for absolutePath is not found.
      */
-    public static InputFileWrapper valueOf(
-            String absolutePath, DefaultConverter.DoxiaFormat format, String charsetName, boolean removeAfterConversion)
+    public static InputFileWrapper valueOf(String absolutePath, DefaultConverter.DoxiaFormat format, String charsetName)
             throws UnsupportedEncodingException, FileNotFoundException {
-        return new InputFileWrapper(absolutePath, format, charsetName, removeAfterConversion);
+        return new InputFileWrapper(absolutePath, format, charsetName);
     }
 
     public DefaultConverter.DoxiaFormat getFormat() {

--- a/src/test/java/org/apache/maven/doxia/DefaultConverterTest.java
+++ b/src/test/java/org/apache/maven/doxia/DefaultConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultConverterTest {
+
+    @Test
+    void testExecuteCommand() throws IOException, InterruptedException {
+        DefaultConverter.executeCommand("git", "version");
+    }
+
+    @Test
+    void testExecuteInvalidCommand() throws IOException, InterruptedException {
+        assertThrows(IOException.class, () -> {
+            DefaultConverter.executeCommand("invalid command");
+        });
+    }
+}


### PR DESCRIPTION
replace with converted markup

This allows to keep the git history of converted input files (in case those are part of a git repository)